### PR TITLE
Adding 4.5 new errors

### DIFF
--- a/source/gcc.rst
+++ b/source/gcc.rst
@@ -13,13 +13,13 @@ Sauf indication contraire, gcc_ est lancé avec les arguments ``-Wall -Werror -s
 
 :index:`control reaches end of non-void function (gcc)`
 -------------------------------------------------------
-.. sectionauthor:: Olivier Bonaventure 
+.. sectionauthor:: Olivier Bonaventure
 
 
 .. literalinclude:: src/noreturn/noreturn.c
    :language: c
 
-Lorsque ce programme est compilé en utilisant gcc_, il retourne l'erreur 
+Lorsque ce programme est compilé en utilisant gcc_, il retourne l'erreur
 :index:`control reaches end of non-void function (gcc)`. Cette erreur indique que l'étudiant a
 oublié de retourner la valeur de retour de la fonction ``f`` (dans ce cas, la valeur
 attendue est de type ``int``).
@@ -28,9 +28,79 @@ attendue est de type ``int``).
    :language: console
 
 
+:index:`conflicting types for \<function\>`
+------------------------------------------
+.. sectionauthor:: Nicolas Rybowski
+
+.. literalinclude:: src/conflictingtype/conflictingtype.c
+    :language: c
+
+Cette erreur signifie généralement que le fonction incriminée surcharge une fonction
+déjà existante dans un package inclus dans le programme. Dans cet exemple, il s'agit de la fonction
+``strcpy`` du package ``string.h``.
+
+La solution la plus simple est de renommer sa fonction afin d'éviter le conflit, par exemple ```my_strcpy``.
+
+Il est toutefois possible de redefinir une telle fonction en utilisant la même signature. Ceci est
+illustré avec la seconde fonction qui ne génère pas d'erreur. Cette redéfinition ne sera valable que localement.
+
+.. literalinclude:: src/conflictingtype/conflictingtype.gcc
+   :language: console
+
+
+:index:`implicit declaration of function \<function\>`
+------------------------------------------------------
+
+.. sectionauthor:: Nicolas Rybowski
+
+.. literalinclude:: src/implicit/implicit.c
+    :language: c
+
+Cette erreur signifie que la fonction faisant appel à cette fonction spécifique ne peut la voir, elle ne
+se situe pas dans sa portée. Dans ce cas particulier, la fonction ``sum`` se trouve en dessous de la fonction appelante (ici ``main``).
+
+De manière générale en C, pour pouvoir appeler une fonction dans un même fichier, il faut que celle ci soit définie `avant` la fonction appelante.
+
+.. literalinclude:: src/implicit/implicit.gcc
+   :language: console
+
+Une autre variante de cette erreur peut être trouvée dans l'exemple ci-dessous.
+
+.. literalinclude:: src/implicit2/implicit2.c
+    :language: c
+
+Dans ce cas ci, l'oubli de l'``include`` provoque cette erreur. Ici, gcc_ détecte qu'il s'agit d'un potentiel appel système, aussi
+il conseille le bon package à inclure.
+
+.. literalinclude:: src/implicit2/implicit2.gcc
+   :language: console
 
 
 
+:index:`\<var\> undeclared (first use in this function)`
+--------------------------------------------------------
 
+.. sectionauthor:: Nicolas Rybowski
 
+.. literalinclude:: src/undeclared/undeclared.c
+    :language: c
 
+Cette erreur signifie que l'on fait usage d'une variable non déclarée ou dont la portée n'est pas suffisante.
+
+.. literalinclude:: src/undeclared/undeclared.gcc
+   :language: console
+
+:index:`passing argument \<value\> of ‘\<function\>’ makes pointer from integer without a cast`
+-----------------------------------------------------------------------------------------------
+
+.. sectionauthor:: Nicolas Rybowski
+
+.. literalinclude:: src/incompatibleptr/incompatibleptr.c
+    :language: c
+
+Cette erreur signifie que l'on ne passe pas un pointeur en argument comme réclamé, mais une valeur.
+
+Dans ce cas particulier, on passe une valeur de type ``int`` au lieu d'un pointeur vers un ``int``.
+
+.. literalinclude:: src/incompatibleptr/incompatibleptr.gcc
+   :language: console

--- a/source/gcc.rst
+++ b/source/gcc.rst
@@ -39,7 +39,7 @@ Cette erreur signifie généralement que le fonction incriminée surcharge une f
 déjà existante dans un package inclus dans le programme. Dans cet exemple, il s'agit de la fonction
 ``strcpy`` du package ``string.h``.
 
-La solution la plus simple est de renommer sa fonction afin d'éviter le conflit, par exemple ```my_strcpy``.
+La solution la plus simple est de renommer sa fonction afin d'éviter le conflit, par exemple ``my_strcpy``.
 
 Il est toutefois possible de redefinir une telle fonction en utilisant la même signature. Ceci est
 illustré avec la seconde fonction qui ne génère pas d'erreur. Cette redéfinition ne sera valable que localement.
@@ -69,7 +69,8 @@ Une autre variante de cette erreur peut être trouvée dans l'exemple ci-dessous
 .. literalinclude:: src/implicit2/implicit2.c
     :language: c
 
-Dans ce cas ci, l'oubli de l'``include`` provoque cette erreur. Ici, gcc_ détecte qu'il s'agit d'un potentiel appel système, aussi
+Dans ce cas ci, l'oubli de l'``include`` provoque cette erreur. Ici, gcc_ détecte
+qu'il s'agit d'un potentiel appel à une fonction venant d'une bibliothèque, aussi
 il conseille le bon package à inclure.
 
 .. literalinclude:: src/implicit2/implicit2.gcc

--- a/source/src/conflictingtype/Makefile
+++ b/source/src/conflictingtype/Makefile
@@ -1,0 +1,18 @@
+GCC= gcc
+CLANG= clang
+
+GCC_CFLAGS=-c -Wall -Wextra -std=c99
+CLANG_CFLAGS=-c -Weverything -fcaret-diagnostics -fdiagnostics-fixit-info -std=c99
+
+SRC=$(wildcard *.c)
+OBJ=$(SRC:.c=.o)
+
+all: $(SRC:.c=.gcc) $(SRC:.c=.clang)
+
+# - indicates that make must ignore stderr
+$(SRC:.c=.gcc):	$(SRC)
+	-$(GCC) $(GCC_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.gcc)
+
+$(SRC:.c=.clang):  $(SRC)
+	-$(CLANG) $(CLANG_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.clang)
+

--- a/source/src/conflictingtype/conflictingtype.c
+++ b/source/src/conflictingtype/conflictingtype.c
@@ -1,0 +1,28 @@
+#include<stdio.h>
+#include<stdlib.h>
+
+#include<string.h>
+
+char *strcpy(const char *src, int len){
+  char *dest = malloc(sizeof(char)*len);
+  if (!dest)
+    return NULL;
+
+  int i;
+  for(i = 0; src[i] != '\0'; i++){
+    dest[i] = src[i];
+  }
+  dest[i+1] = '\0';
+
+  return dest;
+}
+
+char *strcpy(char *dest, const char *src){
+  int i;
+  for(i = 0; src[i] != '\0'; i++){
+    dest[i] = src[i];
+  }
+  dest[i+1] = '\0';
+
+  return dest;
+}

--- a/source/src/conflictingtype/conflictingtype.clang
+++ b/source/src/conflictingtype/conflictingtype.clang
@@ -1,0 +1,10 @@
+conflictingtype.c:6:7: error: conflicting types for 'strcpy'
+char *strcpy(const char *src, int len){
+      ^
+/usr/include/string.h:125:14: note: previous declaration is here
+extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+             ^
+conflictingtype.c:7:36: warning: implicit conversion changes signedness: 'int' to 'unsigned long' [-Wsign-conversion]
+  char *dest = malloc(sizeof(char)*len);
+                                  ~^~~
+1 warning and 1 error generated.

--- a/source/src/conflictingtype/conflictingtype.gcc
+++ b/source/src/conflictingtype/conflictingtype.gcc
@@ -1,0 +1,7 @@
+conflictingtype.c:6:7: error: conflicting types for ‘strcpy’
+ char *strcpy(const char *src, int len){
+       ^
+In file included from conflictingtype.c:4:0:
+/usr/include/string.h:125:14: note: previous declaration of ‘strcpy’ was here
+ extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
+              ^

--- a/source/src/implicit/Makefile
+++ b/source/src/implicit/Makefile
@@ -1,0 +1,18 @@
+GCC= gcc
+CLANG= clang
+
+GCC_CFLAGS=-c -Wall -Wextra -std=c99
+CLANG_CFLAGS=-c -Weverything -fcaret-diagnostics -fdiagnostics-fixit-info -std=c99
+
+SRC=$(wildcard *.c)
+OBJ=$(SRC:.c=.o)
+
+all: $(SRC:.c=.gcc) $(SRC:.c=.clang)
+
+# - indicates that make must ignore stderr
+$(SRC:.c=.gcc):	$(SRC)
+	-$(GCC) $(GCC_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.gcc)
+
+$(SRC:.c=.clang):  $(SRC)
+	-$(CLANG) $(CLANG_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.clang)
+

--- a/source/src/implicit/implicit.c
+++ b/source/src/implicit/implicit.c
@@ -1,0 +1,10 @@
+#include<stdio.h>
+#include<stdlib.h>
+
+int main(void){
+  printf("%i", sum(2, 3));
+}
+
+int sum(int a, int b){
+  return a + b;
+}

--- a/source/src/implicit/implicit.clang
+++ b/source/src/implicit/implicit.clang
@@ -1,0 +1,7 @@
+implicit.c:5:16: warning: implicit declaration of function 'sum' is invalid in C99 [-Wimplicit-function-declaration]
+  printf("%i", sum(2, 3));
+               ^
+implicit.c:8:5: warning: no previous prototype for function 'sum' [-Wmissing-prototypes]
+int sum(int a, int b){
+    ^
+2 warnings generated.

--- a/source/src/implicit/implicit.gcc
+++ b/source/src/implicit/implicit.gcc
@@ -1,0 +1,4 @@
+implicit.c: In function ‘main’:
+implicit.c:5:16: warning: implicit declaration of function ‘sum’ [-Wimplicit-function-declaration]
+   printf("%i", sum(2, 3));
+                ^

--- a/source/src/implicit2/Makefile
+++ b/source/src/implicit2/Makefile
@@ -1,0 +1,18 @@
+GCC= gcc
+CLANG= clang
+
+GCC_CFLAGS=-c -Wall -Wextra -std=c99
+CLANG_CFLAGS=-c -Weverything -fcaret-diagnostics -fdiagnostics-fixit-info -std=c99
+
+SRC=$(wildcard *.c)
+OBJ=$(SRC:.c=.o)
+
+all: $(SRC:.c=.gcc) $(SRC:.c=.clang)
+
+# - indicates that make must ignore stderr
+$(SRC:.c=.gcc):	$(SRC)
+	-$(GCC) $(GCC_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.gcc)
+
+$(SRC:.c=.clang):  $(SRC)
+	-$(CLANG) $(CLANG_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.clang)
+

--- a/source/src/implicit2/implicit2.c
+++ b/source/src/implicit2/implicit2.c
@@ -1,0 +1,4 @@
+int main(void){
+  int a = 5;
+  printf("%i", a);
+}

--- a/source/src/implicit2/implicit2.clang
+++ b/source/src/implicit2/implicit2.clang
@@ -1,0 +1,5 @@
+implicit2.c:3:3: warning: implicitly declaring library function 'printf' with type 'int (const char *, ...)' [-Wimplicit-function-declaration]
+  printf("%i", a);
+  ^
+implicit2.c:3:3: note: include the header <stdio.h> or explicitly provide a declaration for 'printf'
+1 warning generated.

--- a/source/src/implicit2/implicit2.gcc
+++ b/source/src/implicit2/implicit2.gcc
@@ -1,0 +1,6 @@
+implicit2.c: In function ‘main’:
+implicit2.c:3:3: warning: implicit declaration of function ‘printf’ [-Wimplicit-function-declaration]
+   printf("%i", a);
+   ^
+implicit2.c:3:3: warning: incompatible implicit declaration of built-in function ‘printf’
+implicit2.c:3:3: note: include ‘<stdio.h>’ or provide a declaration of ‘printf’

--- a/source/src/incompatibleptr/Makefile
+++ b/source/src/incompatibleptr/Makefile
@@ -1,0 +1,18 @@
+GCC= gcc
+CLANG= clang
+
+GCC_CFLAGS=-c -Wall -Wextra -std=c99
+CLANG_CFLAGS=-c -Weverything -fcaret-diagnostics -fdiagnostics-fixit-info -std=c99
+
+SRC=$(wildcard *.c)
+OBJ=$(SRC:.c=.o)
+
+all: $(SRC:.c=.gcc) $(SRC:.c=.clang)
+
+# - indicates that make must ignore stderr
+$(SRC:.c=.gcc):	$(SRC)
+	-$(GCC) $(GCC_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.gcc)
+
+$(SRC:.c=.clang):  $(SRC)
+	-$(CLANG) $(CLANG_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.clang)
+

--- a/source/src/incompatibleptr/incompatibleptr.c
+++ b/source/src/incompatibleptr/incompatibleptr.c
@@ -1,0 +1,13 @@
+#include<stdio.h>
+#include<stdlib.h>
+
+void double_arg(int* a){
+  *a = *a*2;
+}
+
+int main(void){
+  int a = 5;
+  double_arg(a);
+  printf("%i", a);
+  return 0;
+}

--- a/source/src/incompatibleptr/incompatibleptr.clang
+++ b/source/src/incompatibleptr/incompatibleptr.clang
@@ -1,0 +1,11 @@
+incompatibleptr.c:4:6: warning: no previous prototype for function 'double_arg' [-Wmissing-prototypes]
+void double_arg(int* a){
+     ^
+incompatibleptr.c:10:14: warning: incompatible integer to pointer conversion passing 'int' to parameter of type 'int *'; take the address with & [-Wint-conversion]
+  double_arg(a);
+             ^
+             &
+incompatibleptr.c:4:22: note: passing argument to parameter 'a' here
+void double_arg(int* a){
+                     ^
+2 warnings generated.

--- a/source/src/incompatibleptr/incompatibleptr.gcc
+++ b/source/src/incompatibleptr/incompatibleptr.gcc
@@ -1,0 +1,7 @@
+incompatibleptr.c: In function ‘main’:
+incompatibleptr.c:10:14: warning: passing argument 1 of ‘double_arg’ makes pointer from integer without a cast [-Wint-conversion]
+   double_arg(a);
+              ^
+incompatibleptr.c:4:6: note: expected ‘int *’ but argument is of type ‘int’
+ void double_arg(int* a){
+      ^

--- a/source/src/undeclared/Makefile
+++ b/source/src/undeclared/Makefile
@@ -1,0 +1,18 @@
+GCC= gcc
+CLANG= clang
+
+GCC_CFLAGS=-c -Wall -Wextra -std=c99
+CLANG_CFLAGS=-c -Weverything -fcaret-diagnostics -fdiagnostics-fixit-info -std=c99
+
+SRC=$(wildcard *.c)
+OBJ=$(SRC:.c=.o)
+
+all: $(SRC:.c=.gcc) $(SRC:.c=.clang)
+
+# - indicates that make must ignore stderr
+$(SRC:.c=.gcc):	$(SRC)
+	-$(GCC) $(GCC_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.gcc)
+
+$(SRC:.c=.clang):  $(SRC)
+	-$(CLANG) $(CLANG_CFLAGS) $(SRC) -o /dev/null 2> $(SRC:.c=.clang)
+

--- a/source/src/undeclared/undeclared.c
+++ b/source/src/undeclared/undeclared.c
@@ -1,0 +1,5 @@
+#include<stdio.h>
+
+int main(void){
+  printf("%i", a);
+}

--- a/source/src/undeclared/undeclared.clang
+++ b/source/src/undeclared/undeclared.clang
@@ -1,0 +1,4 @@
+undeclared.c:4:16: error: use of undeclared identifier 'a'
+  printf("%i", a);
+               ^
+1 error generated.

--- a/source/src/undeclared/undeclared.gcc
+++ b/source/src/undeclared/undeclared.gcc
@@ -1,0 +1,5 @@
+undeclared.c: In function ‘main’:
+undeclared.c:4:16: error: ‘a’ undeclared (first use in this function)
+   printf("%i", a);
+                ^
+undeclared.c:4:16: note: each undeclared identifier is reported only once for each function it appears in


### PR DESCRIPTION
- conflicting types for \<function\>
- implicit declaration of function \<function\> (2 different)
- \<var\> undeclared (first use in this function)
- passing argument \<value\> of ‘\<function\>’ makes pointer from
integer without a cast